### PR TITLE
feat: deprecate JOURNEY_MAPS_API_KEY env with JOURNEY_MAPS_TILES_API_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The package is meant as a client for the [Journey Maps API] and is based on the 
 
 #### Precondition
 
-In order to access styles and tile data, you need to register your application to the [Journey Maps Tile API] to receive an API Key.
+In order to access styles and tile data, you need to register your application to the [Journey Maps Tiles API] to receive an API Key.
 Create an account (e.g. using SwissPass Login) to be able to setup an application and then register this application to the API.
 
 #### In code usage
@@ -79,7 +79,7 @@ Make the API Key accessible to your application. Either
 
 1. add it as env var (not recommended):
 ```sh
-JOURNEY_MAPS_API_KEY='YOUR_API_KEY_HERE'
+JOURNEY_MAPS_TILES_API_KEY='YOUR_API_KEY_HERE'
 ```
 2. Or use a package such as [envied](https://pub.dev/packages/envied) for clean env var handling and
    *obfuscating* your API key, making it harder to reverse engineer (in public apps!). Pass the env key to the
@@ -275,4 +275,4 @@ See [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
 
 [Flutter Maplibre GL plugin]: (https://github.com/maplibre/flutter-maplibre-gl/tree/main)
 
-[Journey Maps Tile API]: (https://developer.sbb.ch/apis/journey-maps-tiles/information)
+[Journey Maps Tiles API]: (https://developer.sbb.ch/apis/journey-maps-tiles/information)

--- a/example/example.md
+++ b/example/example.md
@@ -9,7 +9,7 @@ class StandardMapRoute extends StatelessWidget {
       appBar: const SBBHeader(title: 'Standard'),
       body: SBBMap(
         isMyLocationEnabled: true,
-        mapStyler: SBBRokasMapStyler.full(), // API key in ENV var
+        mapStyler: SBBRokasMapStyler.full(), // API key in ENV var 'JOURNEY_MAPS_TILES_API_KEY'
       ),
     );
   }
@@ -32,7 +32,7 @@ class StandardMapRoute extends StatelessWidget {
       appBar: const SBBHeader(title: 'Standard'),
       body: SBBMap(
         isMyLocationEnabled: true,
-        mapStyler: SBBRokasMapStyler.full(), // API key in ENV var
+        mapStyler: SBBRokasMapStyler.full(), // API key in ENV var 'JOURNEY_MAPS_TILES_API_KEY'
         initialCameraPosition: _bern, // specifying this will have the map on a smaller zoom level from beginning
         onMapLocatorAvailable: (locator) => locator.trackDeviceLocation(),
       ),

--- a/lib/src/sbb_map/sbb_map.dart
+++ b/lib/src/sbb_map/sbb_map.dart
@@ -54,8 +54,9 @@ class SBBMap extends StatefulWidget {
   /// The [SBBMapStyler] that will control the styling of the map.
   ///
   /// If not given, the [SBBRokasMapStyler] `full` will be used. This styler will
-  /// try to read the [JOURNEY_MAPS_API_KEY] from the environment variables.
-  /// If it is not set, an [APIKeyMissing] exception will be thrown during Runtime.
+  /// try to read the [JOURNEY_MAPS_TILES_API_KEY], for legacy reasons the
+  /// [JOURNEY_MAPS_API_KEY] from the environment variables.
+  /// If both are not set, an [APIKeyMissing] exception will be thrown during Runtime.
   ///
   /// The style switcher button will only be shown if the given [SBBMapStyler] has more
   /// than one style. Use the [SBBRokasMapStyler.noAerial] to hide the style switcher

--- a/lib/src/sbb_map_style/sbb_rokas_map_styler.dart
+++ b/lib/src/sbb_map_style/sbb_rokas_map_styler.dart
@@ -1,3 +1,4 @@
+import 'package:logger/logger.dart';
 import 'package:sbb_maps_flutter/sbb_maps_flutter.dart';
 import 'package:sbb_maps_flutter/src/sbb_map_style/api_key_missing_exception.dart';
 
@@ -27,11 +28,11 @@ class SBBRokasMapStyler {
   /// * `base_dark_v2_ki_v2`
   /// * `aerial_sbb_ki_v2`
   ///
-  /// The ROKAS styles need an API key for the Journey Maps API.
+  /// The ROKAS styles need an API key for the Journey Maps Tiles API.
   ///
   /// Specify the API key:
   /// * as parameter or
-  /// * set the environment variable `JOURNEY_MAPS_API_KEY`.
+  /// * set the environment variable `JOURNEY_MAPS_TILES_API_KEY`
   ///
   /// Throws an [ApiKeyMissing] exception **during runtime** if neither is given.
   ///
@@ -67,11 +68,11 @@ class SBBRokasMapStyler {
   /// * `base_bright_v2_ki_v2`
   /// * `base_dark_v2_ki_v2`
   ///
-  /// The ROKAS styles need an API key for the Journey Maps API.
+  /// The ROKAS styles need an API key for the Journey Maps Tiles API.
   ///
   /// Specify the API key:
   /// * as parameter or
-  /// * set the environment variable `JOURNEY_MAPS_API_KEY`.
+  /// * set the environment variable `JOURNEY_MAPS_TILES_API_KEY`.
   ///
   /// Throws an [ApiKeyMissing] exception **during runtime** if neither is given.
   ///
@@ -94,9 +95,26 @@ class SBBRokasMapStyler {
   }
 
   static String _apiKeyElseThrow(String? apiKey) {
-    final result = apiKey ?? const String.fromEnvironment('JOURNEY_MAPS_API_KEY');
+    String result = apiKey ?? const String.fromEnvironment('JOURNEY_MAPS_TILES_API_KEY');
+    // @Deprecated(Remove in next major (3.x.x))
+    result = result.isEmpty ? _fetchLegacyApiKeyFromEnv() : '';
+
     if (result == '') {
-      throw ApiKeyMissing('JOURNEY_MAPS_API_KEY is not set as env var nor given as parameter.');
+      throw ApiKeyMissing(
+        'Set JOURNEY_MAPS_TILES_API_KEY as env var or as a constructor parameter.',
+      );
+    }
+    return result;
+  }
+
+  static String _fetchLegacyApiKeyFromEnv() {
+    const result = String.fromEnvironment('JOURNEY_MAPS_API_KEY');
+    if (result != '') {
+      final logger = Logger();
+      logger.w(
+        'sbb_maps_flutter: You are currently loading the API Key from the env var JOURNEY_MAPS_API_KEY.\n'
+        'This is deprecated and will be removed in the next major version of the sbb_maps_flutter.',
+      );
     }
     return result;
   }

--- a/lib/src/sbb_map_style/sbb_rokas_map_styler.dart
+++ b/lib/src/sbb_map_style/sbb_rokas_map_styler.dart
@@ -99,7 +99,7 @@ class SBBRokasMapStyler {
     // @Deprecated(Remove in next major (3.x.x))
     if (result.isEmpty) result = _fetchLegacyApiKeyFromEnv();
 
-    if (result == '') {
+    if (result.isEmpty) {
       throw ApiKeyMissing(
         'Set JOURNEY_MAPS_TILES_API_KEY as env var or as a constructor parameter.',
       );
@@ -108,14 +108,14 @@ class SBBRokasMapStyler {
   }
 
   static String _fetchLegacyApiKeyFromEnv() {
-    const result = String.fromEnvironment('JOURNEY_MAPS_API_KEY');
-    if (result != '') {
+    const legacyKey = String.fromEnvironment('JOURNEY_MAPS_API_KEY');
+    if (legacyKey.isNotEmpty) {
       final logger = Logger();
       logger.w(
         'sbb_maps_flutter: You are currently loading the API Key from the env var JOURNEY_MAPS_API_KEY.\n'
         'This is deprecated and will be removed in the next major version of the sbb_maps_flutter.',
       );
     }
-    return result;
+    return legacyKey;
   }
 }

--- a/lib/src/sbb_map_style/sbb_rokas_map_styler.dart
+++ b/lib/src/sbb_map_style/sbb_rokas_map_styler.dart
@@ -97,7 +97,7 @@ class SBBRokasMapStyler {
   static String _apiKeyElseThrow(String? apiKey) {
     String result = apiKey ?? const String.fromEnvironment('JOURNEY_MAPS_TILES_API_KEY');
     // @Deprecated(Remove in next major (3.x.x))
-    result = result.isEmpty ? _fetchLegacyApiKeyFromEnv() : '';
+    if (result.isEmpty) result = _fetchLegacyApiKeyFromEnv();
 
     if (result == '') {
       throw ApiKeyMissing(


### PR DESCRIPTION
### Proposed changes

The JOURNEY_MAPS_API_KEY env var is confusing, since the actual API needed currently is the Journey Maps Tiles API.

closes #47 

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation