### PR TITLE
46 access int data in client

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ The **SBB Karten** demo application is available both in the SBB Enterprise Play
 | Feature                                 | iOS                | Android            |
 |-----------------------------------------| ------------------ | ------------------ |
 | Gesture                                 | :white_check_mark: | :white_check_mark: |
+| Accessing INT Tiles & POIs              | :white_check_mark: | :white_check_mark: |
 | Camera                                  | :white_check_mark: | :white_check_mark: |
 | Map Styles (including ROKAS Styles)     | :white_check_mark: | :white_check_mark: |
 | Location (including device tracking)    | :white_check_mark: | :white_check_mark: |
@@ -187,6 +188,24 @@ const SBBMapProperties({
     this.dragEnabled = true,
   });
 ```
+
+#### Accessing INT Tiles & POIs
+
+In order to access the INT data from [Journey Maps Tiles INT API], you need to register your application there and receive
+a corresponding API Key. API Keys from the PROD API will not work. After that, either set the environment variable 
+`SBB_MAPS_INT_ENABLED` to `true`:
+
+```bash
+SBB_MAPS_INT_ENABLED=true
+```
+
+or pass the `useIntegrationData` constructor parameter to a `SBBRokasMapStyler`:
+
+```dart
+SBBRokasMapStyler.full(apiKey: Env.MY_INT_API_KEY_NAME, useIntegrationData=true);
+```
+
+Using INT data will log to console as an info.
 
 ### Gallery and Examples
 
@@ -272,7 +291,6 @@ See [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
 
 
 [Journey Maps API]: (https://developer.sbb.ch/apis/journey-maps/information)
-
 [Flutter Maplibre GL plugin]: (https://github.com/maplibre/flutter-maplibre-gl/tree/main)
-
 [Journey Maps Tiles API]: (https://developer.sbb.ch/apis/journey-maps-tiles/information)
+[Journey Maps Tiles INT API]: (https://developer-int.sbb.ch/apis/journey-maps-tiles/information)

--- a/example/lib/env.dart
+++ b/example/lib/env.dart
@@ -6,4 +6,6 @@ part 'env.g.dart';
 abstract class Env {
   @EnviedField(varName: 'JOURNEY_MAPS_TILES_API_KEY', obfuscate: true)
   static String journeyMapsTilesApiKey = _Env.journeyMapsTilesApiKey;
+  @EnviedField(varName: 'JOURNEY_MAPS_TILES_INT_API_KEY', obfuscate: true)
+  static String journeyMapsTilesIntApiKey = _Env.journeyMapsTilesIntApiKey;
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:design_system_flutter/design_system_flutter.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:sbb_maps_example/routes/integration_data_route.dart';
 import 'routes/camera_route.dart';
 import 'routes/custom_ui_route.dart';
 import 'routes/display_annotations_route.dart';
@@ -56,6 +57,7 @@ class _MainAppState extends State<MainApp> {
             '/poi': (context) => const POIRoute(),
             '/routing': (context) => const RoutingRoute(),
             '/map_properties': (context) => const MapPropertiesRoute(),
+            '/integration_data': (context) => const IntegrationDataRoute(),
             '/display_annotations': (context) => const DisplayAnnotationsRoute(),
             '/track_device_location': (context) => const TrackDeviceLocationRoute(),
           },

--- a/example/lib/routes/features_route.dart
+++ b/example/lib/routes/features_route.dart
@@ -60,6 +60,10 @@ class _FeaturesRouteState extends State<FeaturesRoute> {
                       routeName: '/map_properties',
                     ),
                     _FeatureRoute(
+                      title: 'Integration Data',
+                      routeName: '/integration_data',
+                    ),
+                    _FeatureRoute(
                       title: 'Custom UI',
                       routeName: '/custom_ui',
                     ),

--- a/example/lib/routes/integration_data_route.dart
+++ b/example/lib/routes/integration_data_route.dart
@@ -1,0 +1,107 @@
+import 'package:design_system_flutter/design_system_flutter.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:sbb_maps_example/env.dart';
+import 'package:sbb_maps_example/theme_provider.dart';
+import 'package:sbb_maps_flutter/sbb_maps_flutter.dart';
+
+class IntegrationDataRoute extends StatefulWidget {
+  const IntegrationDataRoute({super.key});
+
+  @override
+  State<IntegrationDataRoute> createState() => _IntegrationDataRouteState();
+}
+
+class _IntegrationDataRouteState extends State<IntegrationDataRoute> {
+  bool useIntegration = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final mapStyler = SBBRokasMapStyler.full(
+      apiKey: useIntegration ? Env.journeyMapsTilesIntApiKey : Env.journeyMapsTilesApiKey,
+      isDarkMode: Provider.of<ThemeProvider>(context).isDark,
+      useIntegrationData: useIntegration,
+    );
+
+    return Scaffold(
+      appBar: const SBBHeader(title: 'Integration Data'),
+      body: SBBMap(
+        mapStyler: mapStyler,
+        isMyLocationEnabled: false,
+        isFloorSwitchingEnabled: true,
+        builder: (context) => Align(
+          alignment: Alignment.topRight,
+          child: Padding(
+            padding: const EdgeInsets.all(sbbDefaultSpacing),
+            child: SBBMapIconButton(
+              onPressed: () {
+                showSBBModalSheet<bool>(
+                  context: context,
+                  title: 'Integration Data',
+                  child: _IntegrationDataModalBody(useIntegration: useIntegration),
+                ).then(_setStateWithProperties);
+              },
+              icon: SBBIcons.gears_small,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _setStateWithProperties(bool? useIntegration) {
+    setState(
+      () {
+        if (useIntegration != null) {
+          this.useIntegration = useIntegration;
+        }
+      },
+    );
+  }
+}
+
+class _IntegrationDataModalBody extends StatefulWidget {
+  const _IntegrationDataModalBody({required this.useIntegration});
+
+  final bool useIntegration;
+
+  @override
+  State<_IntegrationDataModalBody> createState() => _IntegrationDataModalBodyState();
+}
+
+class _IntegrationDataModalBodyState extends State<_IntegrationDataModalBody> {
+  late bool _useIntegration;
+
+  @override
+  void initState() {
+    _useIntegration = widget.useIntegration;
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        vertical: sbbDefaultSpacing,
+        horizontal: sbbDefaultSpacing,
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          SBBCheckboxListItem(
+            value: _useIntegration,
+            label: 'Use INT Data',
+            secondaryLabel: 'Accesses developer-int.sbb.ch data.',
+            onChanged: (v) => setState(() {
+              _useIntegration = v ?? false;
+            }),
+            isLastElement: true,
+          ),
+          const SizedBox(height: sbbDefaultSpacing),
+          SBBPrimaryButton(label: 'Apply Changes', onPressed: () => Navigator.pop(context, _useIntegration)),
+          const SizedBox(height: sbbDefaultSpacing),
+        ],
+      ),
+    );
+  }
+}

--- a/test/src/sbb_map_style/sbb_rokas_map_styler_test.dart
+++ b/test/src/sbb_map_style/sbb_rokas_map_styler_test.dart
@@ -1,49 +1,67 @@
 import 'package:sbb_maps_flutter/sbb_maps_flutter.dart';
+import 'package:sbb_maps_flutter/src/sbb_map_style/api_key_missing_exception.dart';
+import 'package:test/expect.dart';
 import 'package:test/test.dart';
 
 void main() {
   group('Unit Test SBBRokasMapStyler', () {
-    group('initalization', () {
-      test('whenFull_shouldReturnCustomMapStylerWithAllStyleIds', () {
-        // act
-        final actual = SBBRokasMapStyler.full(apiKey: 'key');
+    test('whenFull_shouldReturnCustomMapStylerWithAllStyleIds', () {
+      // act
+      final actual = SBBRokasMapStyler.full(apiKey: 'key');
 
-        // expect
-        expect(actual, isA<SBBCustomMapStyler>());
-        expect(actual.getStyleIds().contains('journey_maps_aerial_v1'), equals(true));
-        expect(actual.getStyleIds().contains('journey_maps_bright_v1'), equals(true));
-      });
+      // expect
+      expect(actual, isA<SBBCustomMapStyler>());
+      expect(actual.getStyleIds().contains('journey_maps_aerial_v1'), equals(true));
+      expect(actual.getStyleIds().contains('journey_maps_bright_v1'), equals(true));
+    });
 
-      test('whenFull_shouldReturnInBrightMode', () {
-        // act
-        final actual = SBBRokasMapStyler.full(apiKey: 'key');
+    test('whenFull_shouldReturnInBrightMode', () {
+      // act
+      final actual = SBBRokasMapStyler.full(apiKey: 'key');
 
-        // expect
-        expect(actual, isA<SBBCustomMapStyler>());
-        expect(actual.isDarkMode, equals(false));
-      });
+      // expect
+      expect(actual, isA<SBBCustomMapStyler>());
+      expect(actual.isDarkMode, equals(false));
+    });
 
-      test('whenFull_shouldReturnStyleUriInBrightMode', () {
-        // arrange
-        const expectedUri = 'https://journey-maps-tiles.geocdn.sbb.ch'
-            '/styles/journey_maps_bright_v1/style.json?api_key=key';
+    test('whenFull_shouldReturnStyleUriInBrightMode', () {
+      // arrange
+      const expectedUri = 'https://journey-maps-tiles.geocdn.sbb.ch'
+          '/styles/journey_maps_bright_v1/style.json?api_key=key';
 
-        // act
-        final actual = SBBRokasMapStyler.full(apiKey: 'key');
+      // act
+      final actual = SBBRokasMapStyler.full(apiKey: 'key');
 
-        // expect
-        expect(actual, isA<SBBCustomMapStyler>());
-        expect(actual.currentStyleURI, equals(expectedUri));
-      });
+      // expect
+      expect(actual, isA<SBBCustomMapStyler>());
+      expect(actual.currentStyleURI, equals(expectedUri));
+    });
 
-      test('whenNoAerial_shouldNotHaveAerial', () {
-        // act
-        final actual = SBBRokasMapStyler.noAerial(apiKey: 'key');
+    test('whenNoAerial_shouldNotHaveAerial', () {
+      // act
+      final actual = SBBRokasMapStyler.noAerial(apiKey: 'key');
 
-        // expect
-        expect(actual, isA<SBBCustomMapStyler>());
-        expect(actual.getStyleIds().contains('journey_maps_aerial_v1'), equals(false));
-      });
+      // expect
+      expect(actual, isA<SBBCustomMapStyler>());
+      expect(actual.getStyleIds().contains('journey_maps_aerial_v1'), equals(false));
+    });
+
+    test('whenNoApiKey_shouldThrowApiKeyMissingException', () {
+      // act + expect
+      expect(() => SBBRokasMapStyler.full(), throwsA(const TypeMatcher<ApiKeyMissing>()));
+    });
+
+    test('whenUseIntegrationDataIsTrue_uriShouldBeIntPointing', () {
+      // arrange
+      const expectedUri = 'https://journey-maps-tiles.geocdn-int.sbb.ch'
+          '/styles/journey_maps_bright_v1/style.json?api_key=key';
+
+      // act
+      final actual = SBBRokasMapStyler.full(apiKey: 'key', useIntegrationData: true);
+
+      // expect
+      expect(actual, isA<SBBCustomMapStyler>());
+      expect(actual.currentStyleURI, equals(expectedUri));
     });
   });
 }


### PR DESCRIPTION
### Proposed changes

Tiles, styles and POI data can be either accessed through the corresponding APIs on developer-int.sbb.ch or developer.sbb.ch.

SBBRokasMapStyler takes this into account. The switch can be made either through a useIntegrationData switch or through an ENV var.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation