### PR TITLE
ci: fix flutter minor version in test workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,7 +113,7 @@ jobs:
           distribution: "temurin"
           cache: "gradle"
 
-      - name: Make secret env file accessible for envied generation.
+      - name: Make secret env file accessible for envied generation
         uses: timheuer/base64-to-file@v1.2
         with:
           fileName: ".env"
@@ -125,7 +125,7 @@ jobs:
       - run: flutter build appbundle --profile --no-pub
 
   build-iOS:
-    name: Build iOS package
+    name: Build iOS
     runs-on: macos-latest
     needs: [validation]
     defaults:
@@ -144,7 +144,7 @@ jobs:
           flutter-version: ${{ matrix.sdk }}
           cache: true
 
-      - name: Make secret env file accessible for envied generation.
+      - name: Make secret env file accessible for envied generation
         uses: timheuer/base64-to-file@v1.2
         with:
           fileName: ".env"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,18 +22,19 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
+          flutter-version: 3.27.x
           channel: stable
           cache: true
 
-      - name: flutter setup
+      - name: Flutter setup
         run: |
           flutter doctor -v
           flutter pub get
 
-      - name: format check
+      - name: Format check
         run: dart format -l 120 -o none --set-exit-if-changed .
 
-      - name: test # takes ~ 60s, hence we store the artifact for sonar
+      - name: Flutter test # takes ~ 60s, hence we store the artifact for sonar
         run: |
           dart run build_runner build --delete-conflicting-outputs
           flutter test --coverage
@@ -69,6 +70,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
+          flutter-version: 3.27.x
           channel: stable
           cache: true
 
@@ -95,12 +97,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: ["3.22.3", ""]
+        sdk: ["3.22.3", "3.27.x"]
     steps:
       - uses: actions/checkout@v4
 
       - uses: subosito/flutter-action@v2
         with:
+          channel: stable
           flutter-version: ${{ matrix.sdk }}
           cache: true
 
@@ -131,12 +134,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: ["3.22.3", ""]
+        sdk: ["3.22.3", "3.27.x"]
     steps:
       - uses: actions/checkout@v4
 
       - uses: subosito/flutter-action@v2
         with:
+          channel: stable
           flutter-version: ${{ matrix.sdk }}
           cache: true
 
@@ -149,4 +153,4 @@ jobs:
 
       - run: flutter pub get
       - run: dart run build_runner build --delete-conflicting-outputs
-      - run: flutter build ios --simulator
+      - run: flutter build ios --no-codesign


### PR DESCRIPTION
### Proposed changes

In order not to mix changes of the Flutter SDK with test outcome, we also fix the upper Flutter SDK version to a minor version (note that patches will be taken from latest available on stable).

Only in the nightly build, the Flutter SDK is **not** limited (for early failure alerting).

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation