### PR TITLE
fix: poi controller available only called first style loaded

### DIFF
--- a/lib/src/sbb_map/sbb_map.dart
+++ b/lib/src/sbb_map/sbb_map.dart
@@ -359,7 +359,7 @@ class _SBBMapState extends State<SBBMap> {
     }
 
     _poiController.synchronizeWithNewStyle();
-    if (widget.poiSettings.onPoiControllerAvailable != null) {
+    if (widget.poiSettings.onPoiControllerAvailable != null && _isFirstTimeStyleLoaded) {
       widget.poiSettings.onPoiControllerAvailable!(_poiController);
     }
 


### PR DESCRIPTION
### Proposed changes

The poi controller callback should only be called the first time the style is loaded. 

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation