### PR TITLE
chore: nightly build with 3.29.x

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -27,6 +27,6 @@ jobs:
     needs: [ test ]
     uses: ./.github/workflows/example_app_build.yml
     with:
-      flutter_sdks: '["3.27.4",""]'  # the empty one will use the latest stable channel sdk
+      flutter_sdks: '["3.29.3",""]'  # the empty one will use the latest stable channel sdk
     secrets:
       example_app_env_file_base64: ${{ secrets.EXAMPLE_APP_ENV_FILE_PROD_BASE64 }}


### PR DESCRIPTION
This adds a change forgotten when 3.27.x support was dropped.