### PR TITLE
feat: use setStyle of MapLibre controller

### DIFF
--- a/lib/src/sbb_map/sbb_map.dart
+++ b/lib/src/sbb_map/sbb_map.dart
@@ -268,6 +268,7 @@ class _SBBMapState extends State<SBBMap> {
     _mapLocator.dispose();
     _routingController.dispose();
     _floorController.dispose();
+    _poiController.dispose();
     widget.mapStyler.dispose();
     super.dispose();
   }

--- a/lib/src/sbb_map/sbb_map.dart
+++ b/lib/src/sbb_map/sbb_map.dart
@@ -252,9 +252,8 @@ class _SBBMapState extends State<SBBMap> {
     super.didUpdateWidget(oldWidget);
     if (!identical(oldWidget.mapStyler, widget.mapStyler)) {
       final hasDifferentStyle = oldWidget.mapStyler.currentStyleURI != widget.mapStyler.currentStyleURI;
-      oldWidget.mapStyler.removeListener(_reactToStyleChange);
+      _disposeMapStyler(oldWidget.mapStyler);
       widget.mapStyler.addListener(_reactToStyleChange);
-      oldWidget.mapStyler.dispose();
 
       if (hasDifferentStyle) {
         _mlController.future.then((c) => c.setStyle(widget.mapStyler.currentStyleURI));
@@ -267,7 +266,8 @@ class _SBBMapState extends State<SBBMap> {
     _mapLocator.removeListener(_setState);
     _floorController.removeListener(_setState);
     _routingController.removeListener(_setState);
-    widget.mapStyler.removeListener(_reactToStyleChange);
+
+    _disposeMapStyler(widget.mapStyler);
     if (_mapAnnotator.isCompleted) {
       _mapAnnotator.future.then((a) => a.dispose());
     }
@@ -275,7 +275,6 @@ class _SBBMapState extends State<SBBMap> {
     _routingController.dispose();
     _floorController.dispose();
     _poiController.dispose();
-    widget.mapStyler.dispose();
     super.dispose();
   }
 
@@ -402,6 +401,11 @@ class _SBBMapState extends State<SBBMap> {
       northeast: const LatLng(47.8308275417, 10.6427014502),
     ),
   );
+
+  void _disposeMapStyler(SBBMapStyler oldMapStyler) {
+    oldMapStyler.removeListener(_reactToStyleChange);
+    oldMapStyler.dispose();
+  }
 
   void _completeAnnotatorIfNecessary() {
     if (!_mapAnnotator.isCompleted) {

--- a/lib/src/sbb_map/sbb_map.dart
+++ b/lib/src/sbb_map/sbb_map.dart
@@ -265,6 +265,10 @@ class _SBBMapState extends State<SBBMap> {
     if (_mapAnnotator.isCompleted) {
       _mapAnnotator.future.then((a) => a.dispose());
     }
+    _mapLocator.dispose();
+    _routingController.dispose();
+    _floorController.dispose();
+    widget.mapStyler.dispose();
     super.dispose();
   }
 

--- a/lib/src/sbb_map/sbb_map.dart
+++ b/lib/src/sbb_map/sbb_map.dart
@@ -382,22 +382,18 @@ class _SBBMapState extends State<SBBMap> {
     _isFirstTimeStyleLoaded = false;
   }
 
-  Future<void> _delayedMoveToCHBounds() {
-    return Future.delayed(const Duration(milliseconds: 10)).then(
-      (_) => _controller.future.then(
-        (c) => c.animateCameraMove(cameraUpdate: _getSwitzerlandLatLngBounds(), duration: Durations.short1),
-      ),
-    );
-  }
+  Future<void> _delayedMoveToCHBounds() => Future.delayed(const Duration(milliseconds: 10)).then(
+    (_) => _controller.future.then(
+      (c) => c.animateCameraMove(cameraUpdate: _getSwitzerlandLatLngBounds(), duration: Durations.short1),
+    ),
+  );
 
-  SBBCameraUpdate _getSwitzerlandLatLngBounds() {
-    return SBBCameraUpdate.newLatLngBounds(
-      LatLngBounds(
-        southwest: const LatLng(45.7769477403, 5.93960949059),
-        northeast: const LatLng(47.8308275417, 10.6427014502),
-      ),
-    );
-  }
+  SBBCameraUpdate _getSwitzerlandLatLngBounds() => SBBCameraUpdate.newLatLngBounds(
+    LatLngBounds(
+      southwest: const LatLng(45.7769477403, 5.93960949059),
+      northeast: const LatLng(47.8308275417, 10.6427014502),
+    ),
+  );
 
   void _completeAnnotatorIfNecessary() {
     if (!_mapAnnotator.isCompleted) {

--- a/lib/src/sbb_map/sbb_map.dart
+++ b/lib/src/sbb_map/sbb_map.dart
@@ -249,7 +249,7 @@ class _SBBMapState extends State<SBBMap> {
   @override
   void didUpdateWidget(covariant SBBMap oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (oldWidget.mapStyler != widget.mapStyler) {
+    if (!identical(oldWidget.mapStyler, widget.mapStyler)) {
       oldWidget.mapStyler.removeListener(_setStyleLoadedFalse);
       widget.mapStyler.addListener(_setStyleLoadedFalse);
       oldWidget.mapStyler.dispose();

--- a/lib/src/sbb_map_style/sbb_custom_map_styler.dart
+++ b/lib/src/sbb_map_style/sbb_custom_map_styler.dart
@@ -86,8 +86,7 @@ class SBBCustomMapStyler with ChangeNotifier implements SBBMapStyler {
           _aerialStyle == other._aerialStyle &&
           _preAerialStyle == other._preAerialStyle &&
           _isDarkMode == other._isDarkMode &&
-          _isAerialStyle == other._isAerialStyle &&
-          hasListeners == other.hasListeners;
+          _isAerialStyle == other._isAerialStyle;
 
   @override
   int get hashCode =>
@@ -96,6 +95,5 @@ class SBBCustomMapStyler with ChangeNotifier implements SBBMapStyler {
       _aerialStyle.hashCode ^
       _preAerialStyle.hashCode ^
       _isDarkMode.hashCode ^
-      _isAerialStyle.hashCode ^
-      hasListeners.hashCode;
+      _isAerialStyle.hashCode;
 }


### PR DESCRIPTION
This PR enables faster runtime style switching by using the MapLibreController setStyle method instead of relying on Flutter's state management mechanism.

==
closes #163 